### PR TITLE
Fix npm COPY cmd from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM node:10.11.0-alpine
 
 WORKDIR /usr/src/app
 
-COPY package*.json ./
+COPY package.json ./
+
 RUN npm install
 RUN npm install -g knex
 


### PR DESCRIPTION
Only include package.json to be used on the COPY cmd in Dockerfile. Including package-lock.json brought dependencies problems because couldn't find local files in container.